### PR TITLE
feat: allows `this` to be the typeConfig string

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,7 +4,7 @@ const OPTIONAL = 'optional';
 export default function argsert (typeConfig, ...args) {
   if (typeof typeConfig !== 'string' || (!isRequired(typeConfig) && !isOptional(typeConfig))) {
     args = [typeConfig, ...args];
-    typeConfig = '';
+    typeConfig = this || '';
   }
 
   const types = getTypes(typeConfig);

--- a/test.js
+++ b/test.js
@@ -146,6 +146,14 @@ test('Function.prototype.apply with the arguments object', t => {
   t.true(foo('[string|number] <object>', 'bar', {}));
 });
 
+test('allows `this` to be the typeConfig string', t => {
+  function foo () {
+    return argsert.apply('<null|object> [number]', arguments);
+  }
+
+  t.true(foo({ bar: 'baz' }));
+});
+
 test('Function.prototype.call with the arguments object spread', t => {
   function foo () {
     return argsert.call(this, ...arguments);


### PR DESCRIPTION
@bcoe I think this would probably be even closer to how `yargs` would use this lib[, once transpilation goes as far back as node v0.10]. 😄 